### PR TITLE
Fix crash when opening video on iOS 18

### DIFF
--- a/src/MarkViewController.swift
+++ b/src/MarkViewController.swift
@@ -181,7 +181,9 @@ class MarkViewController: UIViewController, UIGestureRecognizerDelegate, UITextF
                 self.locationLabel.text = "frame 677(+24)\n2821.2 ms"
             }
         } else {
-            let options: PHVideoRequestOptions? = nil
+            let options = PHVideoRequestOptions()
+            // Request the original to get the non-slowed version
+            options.version = .original
             PHImageManager.default().requestAVAsset(
                 forVideo: (model as! PHVideoModel).asset,
                 options: options


### PR DESCRIPTION
Fixes #13.

On iOS 18, opening a recorded video crashes with the following error:

```
IsItSnappy/MarkViewController.swift:28:
Fatal error: 'try!' expression unexpectedly raised an error: Error Domain=AVFoundationErrorDomain Code=-11884
"Cannot Access URL"
UserInfo={
    NSLocalizedFailureReason=The sandbox extension was not issued.,
    NSLocalizedDescription=Cannot Access URL,
    NSUnderlyingError=0x3002b1980 {
        Error Domain=NSOSStatusErrorDomain Code=-17507 "(null)"
    }
}
```

This is caused by the logic in PlayerInfo.getInnerAsset to bypass the composition's frame rate ramp by creating an AVURLAsset if we get an AVComposition.

We can avoid this altogether by requesting the original video without slo-mo effects from PHImageManager.